### PR TITLE
IDataSource constructor() removal

### DIFF
--- a/DataSource/IDataSource.php
+++ b/DataSource/IDataSource.php
@@ -11,8 +11,6 @@ namespace NiftyGrid;
 
 interface IDataSource
 {
-	public function __construct($data);
-
 	public function getData();
 
 	public function getCount($column = "*");


### PR DESCRIPTION
Is there any reason for declaring constructor? I would like to extend it with second parameter.

Thanks
