### PR TITLE
Translatable layout, Twitter bootstrap classes, exact text filter, eqalLower and equalHigher

### DIFF
--- a/Components/Column.php
+++ b/Components/Column.php
@@ -329,10 +329,10 @@ class Column extends \Nette\Application\UI\PresenterComponent
 	/**
 	 * @return Column
 	 */
-	public function setTextFilter()
+	public function setTextFilter($exact = FALSE)
 	{
 		$this->parent['gridForm'][$this->parent->name]['filter']->addText($this->name, $this->label.":");
-		$this->filterType = FilterCondition::TEXT;
+		$this->filterType = ($exact === FALSE) ? (FilterCondition::TEXT) : (FilterCondition::EQUAL);
 
 		return $this;
 	}

--- a/FilterCondition.php
+++ b/FilterCondition.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * NiftyGrid - DataGrid for Nette
  *
@@ -7,15 +8,18 @@
  * @license     New BSD Licence
  * @link        http://addons.nette.org/cs/niftygrid
  */
+
 namespace NiftyGrid;
 
 use Nette\Utils\Strings;
+
 /**
  * @author     Jakub Holub
  */
 class FilterCondition extends \Nette\Object
 {
 	/* filter types */
+
 	const TEXT = "text";
 	const SELECT = "select";
 	const NUMERIC = "numeric";
@@ -32,10 +36,11 @@ class FilterCondition extends \Nette\Object
 	const EQUAL = "equal";
 	const HIGHER = "higher";
 	const HIGHEREQUAL = "higherEqual";
+	const EQUALHIGHER = "equalHigher";
 	const LOWER = "lower";
 	const LOWEREQUAL = "lowerEqual";
+	const EQUALLOWER = "equalLower";
 	const DIFFERENT = "different";
-
 	const DATE_EQUAL = "dateEqual";
 	const DATE_HIGHER = "dateHigher";
 	const DATE_HIGHEREQUAL = "dateHigherEqual";
@@ -50,7 +55,7 @@ class FilterCondition extends \Nette\Object
 	 */
 	public static function like($s)
 	{
-		$escape = array(".", "%","_", "'");
+		$escape = array(".", "%", "_", "'");
 		$replace = array("\.", "\%", "\_");
 		return str_replace($escape, $replace, $s);
 	}
@@ -62,12 +67,12 @@ class FilterCondition extends \Nette\Object
 	 */
 	public static function getConditionsByType($type)
 	{
-		if($type == self::TEXT)
+		if ($type == self::TEXT)
 			return array(
 				self::ENDSWITH => "%",
 				self::STARTSWITH => "%",
 			);
-		elseif($type == self::DATE)
+		elseif ($type == self::DATE)
 			return array(
 				self::DATE_EQUAL => "=",
 				self::DATE_DIFFERENT => "<>",
@@ -76,8 +81,10 @@ class FilterCondition extends \Nette\Object
 				self::DATE_LOWEREQUAL => "<=",
 				self::DATE_LOWER => "<",
 			);
-		elseif($type == self::NUMERIC)
+		elseif ($type == self::NUMERIC)
 			return array(
+				self::EQUALLOWER => "=<",
+				self::EQUALHIGHER => "=>",
 				self::EQUAL => "=",
 				self::DIFFERENT => "<>",
 				self::HIGHEREQUAL => ">=",
@@ -96,32 +103,36 @@ class FilterCondition extends \Nette\Object
 	public static function prepareFilter($value, $type)
 	{
 		/* select, boolean a equal muze byt pouze equal */
-		if(($type == self::SELECT) || ($type == self::BOOLEAN) || ($type == self::EQUAL))
+		if (($type == self::SELECT) || ($type == self::BOOLEAN) || ($type == self::EQUAL))
 			return array(
 				"condition" => self::EQUAL,
 				"value" => $value
 			);
-		elseif($type == self::TEXT){
-			foreach(self::getConditionsByType(self::TEXT) as $name => $condition){
-					if(Strings::endsWith($value, $condition) && !Strings::startsWith($value, $condition) && $name == self::STARTSWITH)
-						return array(
-							"condition" => $name,
-							"value" => Strings::substring($value, 0,"-".Strings::length($condition))
-						);
-					elseif(Strings::startsWith($value, $condition) && !Strings::endsWith($value, $condition) && $name == self::ENDSWITH)
-						return array(
-							"condition" => $name,
-							"value" => Strings::substring($value, Strings::length($condition))
-						);
+		elseif ($type == self::TEXT)
+		{
+			foreach (self::getConditionsByType(self::TEXT) as $name => $condition)
+			{
+				if (Strings::endsWith($value, $condition) && !Strings::startsWith($value, $condition) && $name == self::STARTSWITH)
+					return array(
+						"condition" => $name,
+						"value" => Strings::substring($value, 0, "-" . Strings::length($condition))
+					);
+				elseif (Strings::startsWith($value, $condition) && !Strings::endsWith($value, $condition) && $name == self::ENDSWITH)
+					return array(
+						"condition" => $name,
+						"value" => Strings::substring($value, Strings::length($condition))
+					);
 			}
 			return array(
 				"condition" => self::CONTAINS,
 				"value" => $value
 			);
 		}
-		elseif($type == self::DATE){
-			foreach(self::getConditionsByType(self::DATE) as $name => $condition){
-				if(Strings::startsWith($value, $condition))
+		elseif ($type == self::DATE)
+		{
+			foreach (self::getConditionsByType(self::DATE) as $name => $condition)
+			{
+				if (Strings::startsWith($value, $condition))
 					return array(
 						"condition" => $name,
 						"value" => Strings::substring($value, Strings::length($condition))
@@ -132,9 +143,11 @@ class FilterCondition extends \Nette\Object
 				"value" => $value
 			);
 		}
-		elseif($type == self::NUMERIC){
-			foreach(self::getConditionsByType(self::NUMERIC) as $name => $condition){
-				if(Strings::startsWith($value, $condition))
+		elseif ($type == self::NUMERIC)
+		{
+			foreach (self::getConditionsByType(self::NUMERIC) as $name => $condition)
+			{
+				if (Strings::startsWith($value, $condition))
 					return array(
 						"condition" => $name,
 						"value" => (int) Strings::substring($value, Strings::length($condition))
@@ -158,7 +171,7 @@ class FilterCondition extends \Nette\Object
 			"type" => self::WHERE,
 			"datatype" => self::TEXT,
 			"cond" => " LIKE ?",
-			"value" => "%".self::like($value)."%",
+			"value" => "%" . self::like($value) . "%",
 		);
 	}
 
@@ -188,7 +201,7 @@ class FilterCondition extends \Nette\Object
 			"type" => self::WHERE,
 			"datatype" => self::TEXT,
 			"cond" => " LIKE ?",
-			"value" => self::like($value)."%",
+			"value" => self::like($value) . "%",
 		);
 	}
 
@@ -203,7 +216,7 @@ class FilterCondition extends \Nette\Object
 			"type" => self::WHERE,
 			"datatype" => self::TEXT,
 			"cond" => " LIKE ?",
-			"value" => "%".self::like($value),
+			"value" => "%" . self::like($value),
 		);
 	}
 
@@ -242,6 +255,16 @@ class FilterCondition extends \Nette\Object
 	 * @param string $value
 	 * @return array
 	 */
+	public static function equalHigher($value)
+	{
+		return self::higherEqual($value);
+	}
+
+	/**
+	 * @static
+	 * @param string $value
+	 * @return array
+	 */
 	public static function lower($value)
 	{
 		return array(
@@ -265,6 +288,16 @@ class FilterCondition extends \Nette\Object
 			"cond" => " <= ?",
 			"value" => $value,
 		);
+	}
+
+	/**
+	 * @static
+	 * @param string $value
+	 * @return array
+	 */
+	public static function equalLower($value)
+	{
+		return self::lowerEqual($value);
 	}
 
 	/**

--- a/FilterCondition.php
+++ b/FilterCondition.php
@@ -95,8 +95,8 @@ class FilterCondition extends \Nette\Object
 	 */
 	public static function prepareFilter($value, $type)
 	{
-		/* select nebo boolean muze byt pouze equal */
-		if($type == self::SELECT || $type == self::BOOLEAN)
+		/* select, boolean a equal muze byt pouze equal */
+		if(($type == self::SELECT) || ($type == self::BOOLEAN) || ($type == self::EQUAL))
 			return array(
 				"condition" => self::EQUAL,
 				"value" => $value

--- a/Grid.php
+++ b/Grid.php
@@ -482,11 +482,11 @@ class Grid extends \Nette\Application\UI\Control
 			$filters = array();
 			foreach($this->filter as $name => $value){
 				if(!$this->columnExists($name)){
-					throw new UnknownColumnException("Neexistující sloupec $name");
+					throw new UnknownColumnException("Unknown column $name");
 
 				}
 				if(!$this['columns-'.$name]->hasFilter()){
-					throw new UnknownFilterException("Neexistující filtr pro sloupec $name");
+					throw new UnknownFilterException("Unknown filter for column $name");
 				}
 
 				$type = $this['columns-'.$name]->getFilterType();
@@ -501,10 +501,10 @@ class Grid extends \Nette\Application\UI\Control
 						}
 						$filters[] = $filter;
 					}else{
-						throw new InvalidFilterException("Neplatný filtr");
+						throw new InvalidFilterException("Invalid filter");
 					}
 				}else{
-					throw new InvalidFilterException("Neplatný filtr");
+					throw new InvalidFilterException("Invalid filter");
 				}
 			}
 			return $this->dataSource->filterData($filters);
@@ -530,7 +530,7 @@ class Grid extends \Nette\Application\UI\Control
 			if(in_array($order[0], $this->getColumnNames()) && in_array($order[1], array("ASC", "DESC")) && $this['columns']->components[$order[0]]->isSortable()){
 				$this->dataSource->orderData($order[0], $order[1]);
 			}else{
-				throw new InvalidOrderException("Neplatné seřazení.");
+				throw new InvalidOrderException("Invalid order.");
 			}
 		}
 		catch(InvalidOrderException $e){
@@ -653,20 +653,20 @@ class Grid extends \Nette\Application\UI\Control
 		$form->addContainer($this->name);
 
 		$form[$this->name]->addContainer("rowForm");
-		$form[$this->name]['rowForm']->addSubmit("send","Uložit");
+		$form[$this->name]['rowForm']->addSubmit("send","Save");
 		$form[$this->name]['rowForm']['send']->getControlPrototype()->addClass("grid-editable");
 
 		$form[$this->name]->addContainer("filter");
-		$form[$this->name]['filter']->addSubmit("send","Filtrovat");
+		$form[$this->name]['filter']->addSubmit("send","Filter");
 
 		$form[$this->name]->addContainer("action");
-		$form[$this->name]['action']->addSelect("action_name","Označené:");
-		$form[$this->name]['action']->addSubmit("send","Potvrdit")
+		$form[$this->name]['action']->addSelect("action_name","Mark:");
+		$form[$this->name]['action']->addSubmit("send","Confirm")
 			->getControlPrototype()
 			->addData("select", $form[$this->name]["action"]["action_name"]->getControl()->name);
 
 		$form[$this->name]->addContainer('perPage');
-		$form[$this->name]['perPage']->addSelect("perPage","Záznamů na stranu:", $this->perPageValues)
+		$form[$this->name]['perPage']->addSelect("perPage","Records per page:", $this->perPageValues)
 			->getControlPrototype()
 			->addClass("grid-changeperpage")
 			->addData("gridname", $this->getGridPath())
@@ -769,9 +769,9 @@ class Grid extends \Nette\Application\UI\Control
 		}
 		catch(NoRowSelectedException $e){
 			if($subGrid){
-				$this[$gridName]->flashMessage("Nebyl vybrán žádný záznam.","grid-error");
+				$this[$gridName]->flashMessage("No record selected","grid-error");
 			}else{
-				$this->flashMessage("Nebyl vybrán žádný záznam.","grid-error");
+				$this->flashMessage("No record selected","grid-error");
 			}
 			$this->redirect("this");
 		}

--- a/templates/grid.latte
+++ b/templates/grid.latte
@@ -10,46 +10,72 @@
 *}
 {snippet}
 {if !$control->isSubGrid}
-{$control['gridForm']->render('begin')}
+	{? $control['gridForm']->getElementPrototype()->class = 'grid-gridForm form-inline'}
+	{$control['gridForm']->render('begin')}
 {/if}
-<table n:attr="style => $control->width ? 'width: '.$control->width.';'" class="grid">
+<table n:attr="style => $control->width ? 'width: '.$control->width.';'" class="grid table table-striped table-bordered table-condensed">
 	<thead>
 		<tr class="grid-panel">
 			<th colspan="{$colsCount}">
 				<div class="grid-upper-panel">
-					<a n:href="this" class="grid-current-link" title="Získat odkaz na tuto stránku"></a>
 					<div class="grid-results">
-						celkem {$results} {($results == 1) ? "záznam" : (($results >= 2 && $results <= 4) ? "záznamy" : "záznamů")}{if $paginate} {if (boolean)$results}(Zobrazeno {$viewedFrom} až {$viewedTo}){/if}{/if}
+						<a n:href="this" class="grid-current-link" title="{_'Get link to this page'}"><i class="icon-bookmark"></i></a>
+						{_'Total %s values', $results}
+						 {if $paginate}
+							{if (boolean)$results}
+								{_'(Viewed %s to %s values)', array($viewedFrom, $viewedTo)}
+							{/if}
+						{/if}
 					</div>
 				</div>
 			</th>
 		</tr>
-		<tr n:foreach="$flashes as $flash" class="grid-flash {$flash->type}">
-			<th colspan="{$colsCount}">
-				<span>{$flash->message}</span>
-				<div class="grid-flash-hide"></div>
-			</th>
-		</tr>
+		{*
+			<tr n:foreach="$flashes as $flash" class="grid-flash {$flash->type}">
+				<th colspan="{$colsCount}">
+					<span>{$flash->message}</span>
+					<div class="grid-flash-hide"></div>
+				</th>
+			</tr>
+		*}
 		<tr>
-			<th n:if="$control->hasActionForm()" style="text-align:center; width: 16px;" class="grid-head-column"><input type="checkbox" class="grid-select-all" title="Označit/odznačit všechny záznamy"></th>
-			<th n:foreach="$subGrids as $subGrid" style="width: 26px;" class="grid-head-column"></th>
-			<th n:foreach="$columns as $column" n:attr="style => $column->width ? 'width: '.$column->width.';'" class="grid-head-column">{if $control->hasEnabledSorting() && $column->isSortable()}{var $order = ($control->order == $column->name.' ASC') ? " DESC" : " ASC"}<a n:href="this, 'order' => $column->name.$order" class="grid-ajax" title="Obrátit řazení">{$column->label}</a>{else}{$column->label}{/if}
-				<div class="grid-order" n:if="$column->isSortable() && $control->hasEnabledSorting()">
-					<a n:href="this, 'order' => $column->name.' ASC'" n:class="grid-ajax, grid-order-up ,($control->order && ($control->order == $column->name.' ASC')) ? grid-order-active-up" title="Řadit vzestupně"></a>
-					<a n:href="this, 'order' => $column->name.' DESC'" n:class="grid-ajax, grid-order-down ,($control->order && ($control->order == $column->name.' DESC')) ? grid-order-active-down" title="Řadit sestupně"></a>
-				</div>
+			<th n:if="$control->hasActionForm()" style="text-align:center; width: 16px;" class="grid-head-column">
+				<input type="checkbox" class="grid-select-all" title="{_'Mark/Unmark all records'}">
 			</th>
-			<th n:if="$control->hasButtons() || $control->hasFilterForm()" class="grid-head-column">Akce</th>
+			<th n:foreach="$subGrids as $subGrid" style="width: 26px;" class="grid-head-column"></th>
+			<th n:foreach="$columns as $column" n:attr="style => $column->width ? 'width: '.$column->width.';'" class="grid-head-column">
+				{if $control->hasEnabledSorting() && $column->isSortable()}
+					{var $order = ($control->order == $column->name.' ASC') ? " DESC" : " ASC"}
+					<a n:href="this, 'order' => $column->name.$order" class="grid-ajax" title="{_'Change sorting'}">{$column->label}</a>
+					<span class="pull-right">
+						{if ($control->order && ($control->order == $column->name.' ASC'))}
+							<i class="icon-chevron-up pull-right"></i>
+						{elseif ($control->order && ($control->order == $column->name.' DESC'))}
+							<i class="icon-chevron-down pull-right"></i>
+						{/if}
+					</span>
+				{else}
+					{$column->label}
+				{/if}
+			</th>
+			<th n:if="$control->hasButtons() || $control->hasFilterForm()" class="grid-head-column">
+				{_'Actions'}
+			</th>
 		</tr>
 		<tr n:if="$control->hasFilterForm()">
 			<th n:if="$control->hasActionForm()" class="grid-filter-form"></th>
 			<th n:foreach="$subGrids as $subGrid" class="grid-filter-form"></th>
 			<th n:foreach="$columns as $column" n:attr="class => array(grid-filter-form, $control->isSpecificFilterActive($column->name) ? grid-filter-form-active)">
 				{if $column->hasFilter()}
+					{? $control['gridForm'][$control->name]['filter']['send']->setAttribute('class', 'btn btn-primary')}
 					{$control['gridForm'][$control->name]['filter'][$column->name]->getControl()}
 				{/if}
 			</th>
-			<th class="grid-filter-form">{$control['gridForm'][$control->name]['filter']['send']->getControl()}<a n:if="$control->hasActiveFilter()" n:href="this, filter => NULL, paginator-page => NULL" title="Zrušit filtr" class="grid-filter-reset grid-ajax"></a></th>
+			<th class="grid-filter-form">{$control['gridForm'][$control->name]['filter']['send']->getControl()}
+				<a n:if="$control->hasActiveFilter()" n:href="this, filter => NULL, paginator-page => NULL" title="{_'Remove filter'}" class="grid-filter-reset grid-ajax">
+					<i class="icon-remove"></i>
+				</a>
+			</th>
 		</tr>
 	</thead>
 	<tbody>
@@ -70,7 +96,7 @@
 			<td n:if="$control->hasButtons() || $control->hasFilterForm()" n:attr="class => array(grid-row-cell, $control->isEditable() && $control->activeRowForm == $row[$primaryKey] ? 'grid-edited-cell')">
 				{if $control->activeRowForm == $row[$primaryKey] && $control->isEditable()}
 					{$control['gridForm'][$control->name]['rowForm']['send']->getControl()}
-					<a class="grid-rowForm-cancel grid-ajax" n:href="this" title="Zrušit editaci"></a>
+					<a class="grid-rowForm-cancel grid-ajax" n:href="this" title="{_'Cancel editation'}"></a>
 					{$control['gridForm'][$control->name]['rowForm'][$primaryKey]->getControl()}
 				{else}
 					{foreach $buttons as $button}
@@ -87,7 +113,7 @@
 		{/foreach}
 		{else}
 		<tr>
-			<td class="grid-row-cell" style="background-color:#FFF; font-size:16px;" colspan="{$colsCount}">Žádné záznamy</td>
+			<td class="grid-row-cell" style="background-color:#FFF; font-size:16px;" colspan="{$colsCount}">{_'No records'}</td>
 		</tr>
 		{/if}
 	</tbody>
@@ -95,24 +121,25 @@
 		<tr>
 			<td colspan="{$colsCount}" class="grid-bottom">
 				<span n:if="$control->hasActionForm()" class="grid-action-box">
+						{? $control['gridForm'][$control->name]['action']['send']->setAttribute('class', 'btn btn-primary')}
 						{$control['gridForm'][$control->name]['action']['action_name']->label}
 						{$control['gridForm'][$control->name]['action']['action_name']->getControl()}
 						{$control['gridForm'][$control->name]['action']['send']->getControl()}
 				</span>
-				<span n:if="$paginate" class="grid-perPage">
+				<span n:if="$paginate" class="grid-perPage pull-right">
+						{? $control['gridForm'][$control->name]['perPage']['perPage']->getLabelPrototype()->class = 'control-label'}
+						{? $control['gridForm'][$control->name]['perPage']['perPage']->setAttribute('class', 'grid-changeperpage chzn-select input-small')}
+						{? $control['gridForm'][$control->name]['perPage']['send']->setAttribute('class', 'btn btn-primary')}
+
 						{$control['gridForm'][$control->name]['perPage']['perPage']->label}
 						{$control['gridForm'][$control->name]['perPage']['perPage']->getControl()}
 						{$control['gridForm'][$control->name]['perPage']['send']->getControl()}
 				</span>
 			</td>
 		</tr>
-		<tr n:if="$paginate" class="grid-panel">
-			<td colspan="{$colsCount}">
-				{control paginator}
-			</td>
-		</tr>
 	</tfoot>
 </table>
+{control paginator}
 {if !$control->isSubGrid}
 {$control['gridForm']->render('end')}
 {/if}

--- a/templates/paginator.latte
+++ b/templates/paginator.latte
@@ -9,29 +9,41 @@
 */
 *}
 {if $paginator->pageCount > 1}
-<div class="grid-paginator">
-	{foreach range($paginator->getBase(), $paginator->getPageCount()) as $page}
-	{/foreach}
-	{if !$paginator->isFirst()}
-		<a href="{link this, 'page' => $paginator->getFirstPage()}" class="grid-ajax">&lt;&lt;</a>
-	{else}
-		<span>&lt;&lt;</span>
-	{/if}
-	{if $paginator->getPage() - 1 >= $paginator->getFirstPage()}
-		<a href="{link this, 'page' => $paginator->getPage() - 1}" class="grid-ajax">&lt;</a>
-	{else}
-		<span>&lt;</span>
-	{/if}
-	<span class="grid-current" data-lastpage="{$paginator->getLastPage()}">{$paginator->getPage()}</span>
-	{if $paginator->getPage() + 1 <= $paginator->getLastPage()}
-		<a href="{link this, 'page' => $paginator->getPage() + 1}" class="grid-ajax">&gt;</a>
-	{else}
-		<span>&gt;</span>
-	{/if}
-	{if !$paginator->isLast()}
-		<a href="{link this, 'page' => $paginator->getLastPage()}" class="grid-ajax">&gt;&gt;</a>
-	{else}
-		<span>&gt;&gt;</span>
-	{/if}
+<div class="grid-paginator pagination pagination-centered ">
+	<ul>
+		<li n:class="$paginator->isFirst() ? 'disabled'">
+			{if !$paginator->isFirst()}
+				<a n:href="this, 'page' => $paginator->getFirstPage()" class="ajax">&lt;&lt;</a>
+			{else}
+				<a n:href="this">&lt;&lt;</a>
+			{/if}
+		</li>
+		<li n:class="!($paginator->getPage() - 1 >= $paginator->getFirstPage()) ? 'disabled'">
+			{if $paginator->getPage() - 1 >= $paginator->getFirstPage()}
+				<a n:href="this, 'page' => $paginator->getPage() - 1" class="ajax">&lt;</a>
+			{else}
+				<a n:href="this">&lt;</a>
+			{/if}
+		</li>
+		<li class="active" data-lastpage="{$paginator->getLastPage()}">
+			<a href="this, 'page' => $paginator->getPage()" class ="ajax">
+				{$paginator->getPage()}
+			</a>
+		</li>
+		<li n:class="!($paginator->getPage() + 1 <= $paginator->getLastPage()) ? 'disabled'">
+			{if $paginator->getPage() + 1 <= $paginator->getLastPage()}
+				<a n:href="this, 'page' => $paginator->getPage() + 1" class="ajax">&gt;</a>
+			{else}
+				<a n:href="this">&gt;</a>
+			{/if}
+		</li>
+		<li n:class="$paginator->isLast() ? 'disabled'">
+			{if !$paginator->isLast()}
+				<a n:href="this, 'page' => $paginator->getLastPage()" class="ajax">&gt;&gt;</a>
+			{else}
+				<a n:href="this">&gt;&gt;</a>
+			{/if}
+		</li>
+	</ul>
 </div>
 {/if}


### PR DESCRIPTION
Change all Czech messages in Grid.php and layout into English and translatable.
Little design improvements for Twitter Bootstrap.
Posibility of exact text filter
There was a bug when someone use => or =< instead of >= or <=  
