### PR TITLE
Add method setMessageNoRecords, Show/NoShow foot

### DIFF
--- a/Grid.php
+++ b/Grid.php
@@ -74,6 +74,9 @@ class Grid extends \Nette\Application\UI\Control
 
 	/** @var string */
 	protected $templatePath;
+	
+	/** @var string */
+	public $messageNoRecords = 'Žádné záznamy';
 
 	/**
 	 * @param \Nette\Application\UI\Presenter $presenter
@@ -349,6 +352,14 @@ class Grid extends \Nette\Application\UI\Control
 	public function setWidth($width)
 	{
 		$this->width = $width;
+	}
+	
+	/**
+	 * @param string $messageNoRecords
+	 */
+	public function setMessageNoRecords($messageNoRecords)
+	{
+		$this->messageNoRecords = $messageNoRecords;
 	}
 
 	/**

--- a/templates/grid.latte
+++ b/templates/grid.latte
@@ -107,7 +107,7 @@
 		{/foreach}
 		{else}
 		<tr>
-			<td class="grid-row-cell" style="background-color:#FFF; font-size:16px;" colspan="{$colsCount}">Žádné záznamy</td>
+			<td class="grid-row-cell" style="background-color:#FFF; font-size:16px;" colspan="{$colsCount}">{$control->messageNoRecords}</td>
 		</tr>
 		{/if}
 	</tbody>

--- a/templates/grid.latte
+++ b/templates/grid.latte
@@ -111,7 +111,7 @@
 		</tr>
 		{/if}
 	</tbody>
-	<tfoot>
+	<tfoot n:if="$control->hasActionForm() || $paginate">
 		<tr>
 			<td colspan="{$colsCount}" class="grid-bottom">
 				<span n:if="$control->hasActionForm()" class="grid-action-box">


### PR DESCRIPTION
Add method setMessageNoRecords. We can easily change the displayed message with an empty output.

When there is no action and paging is set to FALSE, then there is no need to see tfoot table.
