### PR TITLE
Fix filter feature in PHP 5.4.7

### DIFF
--- a/libs/NiftyGrid/Grid.php
+++ b/libs/NiftyGrid/Grid.php
@@ -19,7 +19,7 @@ abstract class Grid extends \Nette\Application\UI\Control
 	const ADD_ROW = "addRow";
 
 	/** @persistent array */
-	public $filter;
+	public $filter = array();
 
 	/** @persistent string */
 	public $order;


### PR DESCRIPTION
After update to PHP 5.4.7 filters stop working with an error:

Invalid value for persistent parameter 'filter' in 'tutorsGridControl', expected scalar.
