### PR TITLE
Default value of select editable (Issue #40)

### DIFF
--- a/libs/NiftyGrid/Grid.php
+++ b/libs/NiftyGrid/Grid.php
@@ -933,7 +933,7 @@ abstract class Grid extends \Nette\Application\UI\Control
 					$input = $this['gridForm'][$this->name]['rowForm'][$name];
 					if($input instanceof \Nette\Forms\Controls\SelectBox){
 						$items = $this['gridForm'][$this->name]['rowForm'][$name]->getItems();
-						if(in_array($row[$name], $items)){
+						if(!array_key_exists($row[$name], $items)){
 							$row[$name] = array_search($row[$name], $items);
 						}
 					}


### PR DESCRIPTION
I founded bug in Grid::render, in this part:

``` php
    if($input instanceof \Nette\Forms\Controls\SelectBox){
        $items = $this['gridForm'][$this->name]['rowForm'][$name]->getItems();
        // $items is array( "high"=21, "low"=15, "none"=0 )
        // $row[$name] is "low"
        if(in_array($row[$name], $items)){ // returns true
            // replace "low" with "none"
            $row[$name] = array_search($row[$name], $items);
        }
        // $row[$name] is now "none"
    }
```

https://github.com/Niftyx/NiftyGrid/blob/master/libs/NiftyGrid/Grid.php#L936

I suggest replace in_array() with !array_key_exists():

``` php
        if(!array_key_exists($row[$name], $items)){
```

It should resolve it to the satisfaction of all - if value in table exist as a key,
is used this option, only if doesnt exist as a key, is used option with this as a value.
